### PR TITLE
direnvを使って設定変更をしやすくする

### DIFF
--- a/.envrc.tmpl
+++ b/.envrc.tmpl
@@ -1,0 +1,3 @@
+export SERVICE_FQDN=bandy773.net
+
+export NGINX_PORT=81

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /back/tmp/
 /front/.config
 front/yarn.lock
+.envrc

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 
 初回セットアップ
+direnvをinstallして、 `direnv allow` します。
+ref. https://qiita.com/kompiro/items/5fc46089247a56243a62
 
 ```docker network create bay_network```
 

--- a/back/config/application.rb
+++ b/back/config/application.rb
@@ -23,7 +23,7 @@ module App
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
-    config.hosts << "dev.highchat.ikasekai.com"
+    config.hosts << ENV.fetch('SERVICE_FQDN')
     config.hosts << "back"
     # Configuration for the application, engines, and railties goes here.
     #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       - db
     ports:
       - 3000:3000
+    environment:
+      - SERVICE_FQDN=${SERVICE_FQDN:-dev.highchat.ikasekai.com}
     networks:
       - bay_network
 
@@ -49,7 +51,9 @@ services:
     depends_on:
       - back
     ports:
-      - 80:80
+      - "${NGINX_PORT:-80}:80"
+    environment:
+      - SERVICE_FQDN=${SERVICE_FQDN:-dev.highchat.ikasekai.com}
 networks:
   bay_network:
     external: true

--- a/front/nuxt.config.js
+++ b/front/nuxt.config.js
@@ -39,7 +39,7 @@ export default {
 	],
   axios: {
     baseURL: "http://back:3000/",
-    browserBaseURL: "http://dev.highchat.ikasekai.com/"
+    browserBaseURL: "http://" + process.env.API_BASE_URL + "/"
   },
   // Build Configuration: https://go.nuxtjs.dev/config-build
   build: {

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,7 +1,7 @@
 server {
   listen 80;
   # ドメインもしくはIPを指定
-  server_name dev.highchat.ikasekai.com;
+  server_name ${SERVICE_FQDN};
 
   access_log /var/log/nginx/access.log;
   error_log  /var/log/nginx/error.log;


### PR DESCRIPTION
自分ならこうするなあという envrc/direnv を使った設定方法のPR。
`docker-compose up` するとき、`.envrc` を設定しなければ今まで通りの設定で動き、`.envrc` を置くとその設定で上書き出来ます。